### PR TITLE
Updated SecurityMixin in order to handle SECURE_PROXY_SSL_HEADER

### DIFF
--- a/kaio/mixins/security.py
+++ b/kaio/mixins/security.py
@@ -24,7 +24,7 @@ class SecurityMixin(object):
 
     @property
     def SECURE_PROXY_SSL_HEADER_NAME(self):
-        return get('SECURE_PROXY_SSL_HEADER_NAME', 'HTTP_X_FORWARDED_PROTOCOL')
+        return get('SECURE_PROXY_SSL_HEADER_NAME', 'HTTP_X_FORWARDED_PROTO')
 
     @property
     def SECURE_PROXY_SSL_HEADER_VALUE(self):
@@ -34,5 +34,5 @@ class SecurityMixin(object):
     def SECURE_PROXY_SSL_HEADER(self):
         # required in order to have the request.is_secure() method to work properly in https environments
         # https://docs.djangoproject.com/en/1.10/ref/settings/#secure-proxy-ssl-header
-        # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
+        # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
         return self.SECURE_PROXY_SSL_HEADER_NAME, self.SECURE_PROXY_SSL_HEADER_VALUE

--- a/kaio/mixins/security.py
+++ b/kaio/mixins/security.py
@@ -10,14 +10,29 @@ def get(value, default):
 
 
 class SecurityMixin(object):
-    """Securty base settings"""
+    """
+    Security base settings
+    """
 
     @property
     def SECRET_KEY(self):
-        return get('SECRET_KEY', u'sysadmin, canvia la secret key!!!!')
+        return get('SECRET_KEY', u'sysadmin, change the secret key!!!!')
 
     @property
     def ALLOWED_HOSTS(self):
-        return [h.strip() for h in \
-                get('ALLOWED_HOSTS', '*').split(',')]
+        return [h.strip() for h in get('ALLOWED_HOSTS', '*').split(',')]
 
+    @property
+    def SECURE_PROXY_SSL_HEADER_NAME(self):
+        return get('SECURE_PROXY_SSL_HEADER_NAME', 'HTTP_X_FORWARDED_PROTOCOL')
+
+    @property
+    def SECURE_PROXY_SSL_HEADER_VALUE(self):
+        return get('SECURE_PROXY_SSL_HEADER_VALUE', 'https')
+
+    @property
+    def SECURE_PROXY_SSL_HEADER(self):
+        # required in order to have the request.is_secure() method to work properly in https environments
+        # https://docs.djangoproject.com/en/1.10/ref/settings/#secure-proxy-ssl-header
+        # SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
+        return self.SECURE_PROXY_SSL_HEADER_NAME, self.SECURE_PROXY_SSL_HEADER_VALUE


### PR DESCRIPTION
Added required properties into SecurityMixin in order to have the request.is_secure() method working properly in https environments.
https://docs.djangoproject.com/en/1.10/ref/settings/#secure-proxy-ssl-header