### PR TITLE
Prevent infinite loop for Windows SO.

### DIFF
--- a/kaio/options.py
+++ b/kaio/options.py
@@ -60,8 +60,10 @@ class Options(object):
     def _conf_paths(self):
         paths = []
         current = abspath(".")
-        while current != "/":
+        last = None
+        while current != last:
             paths.append(join(current, DEFAULT_CONF_NAME))
+            last = current
             current = abspath(join(current, pardir))
         return list(reversed(paths))
 


### PR DESCRIPTION
This patch solve problem on Windows. The loop never end because "/" path doesn't exist. With this patch works ok on any OS.