### PR TITLE
Fix Deprecation Warning deleting INTERCEPT_REDIRECTS setting

### DIFF
--- a/kaio/mixins/debug.py
+++ b/kaio/mixins/debug.py
@@ -25,7 +25,6 @@ class DebugMixin(object):
 
     # https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#explicit-setup
     DEBUG_TOOLBAR_PATCH_SETTINGS = False
-    DEBUG_TOOLBAR_CONFIG = {'INTERCEPT_REDIRECTS': False}
     DEBUG_TOOLBAR_MIDDLEWARE = 'debug_toolbar.middleware.DebugToolbarMiddleware'
 
     @property


### PR DESCRIPTION
Since django-debug-toolbar version 1.11 (2014),  the INTERCEPT_REDIRECTS setting was superseded by DISABLE_PANELS. 

As you can see in the documentation (https://django-debug-toolbar.readthedocs.io/en/stable/panels.html?highlight=redirects#redirects) now redirects interception is disabled by default, so this line is not necessary any more.