### PR TITLE
Fix encoding for the log file handler

### DIFF
--- a/kaio/mixins/logs.py
+++ b/kaio/mixins/logs.py
@@ -97,7 +97,7 @@ class LogsMixin(object):
         if self.LOG_FILE:
             handlers['default']['class'] = 'logging.FileHandler'
             handlers['default']['filename'] = self.LOG_FILE
-            handlers['default']['encoding'] = 'utf-8',
+            handlers['default']['encoding'] = 'utf-8'
 
         handlers['mail_admins'] = {
             'level': 'ERROR',


### PR DESCRIPTION
If we enable the handler to write into a file we have the following error.

```
└──╼ ./manage.py runserver
Traceback (most recent call last):
  File "/home/bcanyelles/.pyenv/versions/3.7.0/lib/python3.7/logging/config.py", line 555, in configure
    handler = self.configure_handler(handlers[name])
  File "/home/bcanyelles/.pyenv/versions/3.7.0/lib/python3.7/logging/config.py", line 728, in configure_handler
    result = factory(**kwargs)
  File "/home/bcanyelles/.pyenv/versions/3.7.0/lib/python3.7/logging/__init__.py", line 1041, in __init__
    StreamHandler.__init__(self, self._open())
  File "/home/bcanyelles/.pyenv/versions/3.7.0/lib/python3.7/logging/__init__.py", line 1070, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
TypeError: open() argument 4 must be str or None, not ConvertingTuple

```