### PR TITLE
feat: add debug toolbar allowed hosts

### DIFF
--- a/docs/mixins.rst
+++ b/docs/mixins.rst
@@ -331,6 +331,12 @@ in the ``requirements.txt`` of the project, otherwise we will not have activated
     If ``ENABLE_DEBUG_TOOLBAR`` is ``True`` it automatically appends IPs for showing the toolbar inside contaniers.
     https://django-debug-toolbar.readthedocs.io/en/stable/installation.html#configure-internal-ips
 
+**ALLOWED_HOSTS_DEBUG_TOOLBAR**
+    If you want to set debug toolbar on an environment deployed with docker for testing, INTERNAL_IPS are not enough because the IP from your domain will not be
+    an INTERNAL_IP of the docker image. If ``ENABLE_DEBUG_TOOLBAR`` is ``True`` it will set ALLOWED_HOSTS_DEBUG_TOOLBAR from envvar, expecting a comma separated list.
+    Then, you can override ``SHOW_TOOLBAR_CALLBACK`` debug toolbar config with `kaio.debug_toolbar.show_toolbar` to take this allowed hosts into consideration.
+    https://django-debug-toolbar.readthedocs.io/en/stable/configuration.html#show-toolbar-callback
+
 
 EmailMixin
 ----------

--- a/kaio/debug_toolbar.py
+++ b/kaio/debug_toolbar.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+def show_toolbar(request):
+    """
+    Function to determine whether to show the toolbar on a given page.
+    """
+    return settings.DEBUG and \
+        settings.ENABLE_DEBUG_TOOLBAR and \
+        ((request.META.get("REMOTE_ADDR") in settings.INTERNAL_IPS) or is_host_debug_toolbar_allowed(
+            request.get_host()))
+
+
+def is_host_debug_toolbar_allowed(host):
+    for allowed_host in settings.ALLOWED_HOSTS_DEBUG_TOOLBAR:
+        if host.endswith(allowed_host):
+            return True
+    return False

--- a/kaio/mixins/debug.py
+++ b/kaio/mixins/debug.py
@@ -51,6 +51,12 @@ class DebugMixin(object):
             ips += [ip[:-1] + '1' for ip in docker_ips]
         return ips
 
+    @property
+    def ALLOWED_HOSTS_DEBUG_TOOLBAR(self):
+        if self.ENABLE_DEBUG_TOOLBAR:
+            return get("ALLOWED_HOSTS_DEBUG_TOOLBAR", "").split(",")
+        return []
+
     def _add_debug_toolbar_to_installed_apps(self):
         if 'debug_toolbar' not in self.INSTALLED_APPS:
             self.INSTALLED_APPS.append('debug_toolbar')


### PR DESCRIPTION
Add the ability to config debug toolbar on a deployment taking into consideration: debug, enable_debug_toolbar, internal ips or allowed hosts for debug toolbar.