### PR TITLE
Imp redis scheme

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Change log
 ==========
 
+v1.6.1 (2025-08-11)
+--------------------
+
+* Support to customize Redis scheme with ``REDIS_SCHEME`` default to ``redis``, this allows to use ``rediss`` (with double S) for TLS connections.
+
 v1.6.0 (2025-03-19)
 --------------------
 

--- a/docs/mixins.rst
+++ b/docs/mixins.rst
@@ -26,10 +26,13 @@ production. If a cache type is not defined, it means that we have ``dummy`` cach
 **CACHE_REDIS_DB**
     redis database number that we'll use as cache into redis. By default, ``2``.
 
+**CACHE_REDIS_USER**
+    Password for redis. By default without password.
+
 **CACHE_REDIS_PASSWORD**
     Password for redis. By default without password.
 
-**REDIS_HOST**
+**REDIS_SCHEME**
     redis scheme. By default ``redis``, use ``rediss`` for TLS.
 
 **REDIS_HOST**
@@ -57,8 +60,14 @@ By default use almost same settings as default cache.
 **SESSION_CACHE_REDIS_DB**
     redis database number that we'll use as cache into redis. By default, ``3``.
 
+**SESSION_CACHE_REDIS_USER**
+    Password for redis. By default without password.
+
 **SESSION_CACHE_REDIS_PASSWORD**
     Password for redis. By default without password.
+
+**SESSION_REDIS_SCHEME**
+    redis scheme. By default ``redis``, use ``rediss`` for TLS.
 
 **SESSION_REDIS_HOST**
     redis host name. By default ``REDIS_HOST``

--- a/docs/mixins.rst
+++ b/docs/mixins.rst
@@ -30,6 +30,9 @@ production. If a cache type is not defined, it means that we have ``dummy`` cach
     Password for redis. By default without password.
 
 **REDIS_HOST**
+    redis scheme. By default ``redis``, use ``rediss`` for TLS.
+
+**REDIS_HOST**
     redis host name. By default ``localhost``
 
 **REDIS_PORT**

--- a/kaio/mixins/cache.py
+++ b/kaio/mixins/cache.py
@@ -32,6 +32,10 @@ class CachesMixin(object):
         return get('CACHE_REDIS_DB', 2)
 
     @property
+    def CACHE_REDIS_USER(self):
+        return get('CACHE_REDIS_USER', 'redis')
+
+    @property
     def CACHE_REDIS_PASSWORD(self):
         return get('CACHE_REDIS_PASSWORD', None)
 
@@ -52,8 +56,9 @@ class CachesMixin(object):
         if self.CACHE_TYPE == 'redis':
             CACHE = {
                 'BACKEND': 'django_redis.cache.RedisCache',
-                'LOCATION':  '%s://%s:%s/%s' % (
+                'LOCATION':  '%s://%s%s:%s/%s' % (
                     self.REDIS_SCHEME,
+                    self.CACHE_REDIS_USER + '@' if self.CACHE_REDIS_USER else '',
                     self.REDIS_HOST,
                     self.REDIS_PORT,
                     self.CACHE_REDIS_DB
@@ -105,6 +110,10 @@ class CachesMixin(object):
         return get('SESSION_CACHE_REDIS_DB', 3)
 
     @property
+    def SESSION_CACHE_REDIS_USER(self):
+        return get('SESSION_CACHE_REDIS_USER', self.CACHE_REDIS_USER)
+
+    @property
     def SESSION_CACHE_REDIS_PASSWORD(self):
         return get('SESSION_CACHE_REDIS_PASSWORD', self.CACHE_REDIS_PASSWORD)
 
@@ -130,10 +139,12 @@ class CachesMixin(object):
 
         CACHE = {
             'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION':  '%s://%s:%s/%s' % (self.SESSION_REDIS_SCHEME,
-                                               self.SESSION_REDIS_HOST,
-                                               self.SESSION_REDIS_PORT,
-                                               self.SESSION_CACHE_REDIS_DB),
+            'LOCATION':  '%s://%s%s:%s/%s' % (
+                self.SESSION_REDIS_SCHEME,
+                self.SESSION_CACHE_REDIS_USER + '@' if self.CACHE_REDIS_USER else '',
+                self.SESSION_REDIS_HOST,
+                self.SESSION_REDIS_PORT,
+                self.SESSION_CACHE_REDIS_DB),
             'KEY_PREFIX': self.SESSION_CACHE_PREFIX,
             'TIMEOUT': self.SESSION_CACHE_TIMEOUT,
             'OPTIONS': {

--- a/kaio/mixins/cache.py
+++ b/kaio/mixins/cache.py
@@ -16,6 +16,10 @@ class CachesMixin(object):
         return get('CACHE_TYPE', 'locmem')
 
     @property
+    def REDIS_SCHEME(self):
+        return get('REDIS_SCHEME', 'redis')
+
+    @property
     def REDIS_HOST(self):
         return get('REDIS_HOST', 'localhost')
 
@@ -48,9 +52,12 @@ class CachesMixin(object):
         if self.CACHE_TYPE == 'redis':
             CACHE = {
                 'BACKEND': 'django_redis.cache.RedisCache',
-                'LOCATION':  'redis://%s:%s/%s' % (self.REDIS_HOST,
-                                                   self.REDIS_PORT,
-                                                   self.CACHE_REDIS_DB),
+                'LOCATION':  '%s://%s:%s/%s' % (
+                    self.REDIS_SCHEME,
+                    self.REDIS_HOST,
+                    self.REDIS_PORT,
+                    self.CACHE_REDIS_DB
+                ),
                 'KEY_PREFIX': self.CACHE_PREFIX,
                 'TIMEOUT': self.CACHE_TIMEOUT,
                 'OPTIONS': {
@@ -80,6 +87,10 @@ class CachesMixin(object):
     @property
     def SESSION_CACHE_TYPE(self):
         return get('SESSION_CACHE_TYPE', self.CACHE_TYPE)
+
+    @property
+    def SESSION_REDIS_SCHEME(self):
+        return get('SESSION_REDIS_SCHEME', self.REDIS_SCHEME)
 
     @property
     def SESSION_REDIS_HOST(self):
@@ -119,7 +130,8 @@ class CachesMixin(object):
 
         CACHE = {
             'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION':  'redis://%s:%s/%s' % (self.SESSION_REDIS_HOST,
+            'LOCATION':  '%s://%s:%s/%s' % (self.SESSION_REDIS_SCHEME,
+                                               self.SESSION_REDIS_HOST,
                                                self.SESSION_REDIS_PORT,
                                                self.SESSION_CACHE_REDIS_DB),
             'KEY_PREFIX': self.SESSION_CACHE_PREFIX,

--- a/kaio/mixins/cache.py
+++ b/kaio/mixins/cache.py
@@ -33,7 +33,7 @@ class CachesMixin(object):
 
     @property
     def CACHE_REDIS_USER(self):
-        return get('CACHE_REDIS_USER', 'redis')
+        return get('CACHE_REDIS_USER', None)
 
     @property
     def CACHE_REDIS_PASSWORD(self):

--- a/kaio/mixins/celeryconf.py
+++ b/kaio/mixins/celeryconf.py
@@ -49,7 +49,8 @@ class CeleryMixin(object):
 
         host, port = self.REDIS_HOST, self.REDIS_PORT
         if host and port:
-            return "redis://{host}:{port}/{db}".format(
+            return "{scheme}://{host}:{port}/{db}".format(
+                scheme=self.REDIS_SCHEME,
                 host=host,
                 port=port,
                 db=self.CELERY_REDIS_RESULT_DB,
@@ -146,7 +147,8 @@ class CeleryMixin(object):
                     Check redis package, and REDIS_HOST, REDIS_PORT settings")
 
         if broker_type == 'redis' and redis_available:
-            return 'redis://{host}:{port}/{db}'.format(
+            return '{scheme}://{host}:{port}/{db}'.format(
+                    scheme=self.REDIS_SCHEME,
                     host=self.REDIS_HOST,
                     port=self.REDIS_PORT,
                     db=self.CELERY_REDIS_BROKER_DB)

--- a/kaio/mixins/celeryconf.py
+++ b/kaio/mixins/celeryconf.py
@@ -147,8 +147,17 @@ class CeleryMixin(object):
                     Check redis package, and REDIS_HOST, REDIS_PORT settings")
 
         if broker_type == 'redis' and redis_available:
-            return '{scheme}://{host}:{port}/{db}'.format(
+            redis_auth = ""
+
+            if self.CACHE_REDIS_USER and self.CACHE_REDIS_PASSWORD:
+                redis_auth = "{}:{}@".format(
+                    self.CACHE_REDIS_USER,
+                    self.CACHE_REDIS_PASSWORD,
+                )
+
+            return '{scheme}://{redis_auth}{host}:{port}/{db}'.format(
                     scheme=self.REDIS_SCHEME,
+                    redis_auth=redis_auth,
                     host=self.REDIS_HOST,
                     port=self.REDIS_PORT,
                     db=self.CELERY_REDIS_BROKER_DB)


### PR DESCRIPTION
Added support for TLS connections to redis setting `REDIS_SCHEME` to `rediss` (with double S)

Also added support for authenticated redis connection using `CACHE_REDIS_USER` (`CACHE_REDIS_PASSWORD` was already supported)